### PR TITLE
fix: global metrics native PR + CI workflow tweaks

### DIFF
--- a/.github/workflows/github-activity.yml
+++ b/.github/workflows/github-activity.yml
@@ -18,27 +18,27 @@ jobs:
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           token: ${{ secrets.PAT }}
-          persist-credentials: false
+          persist-credentials: true
       - name: Run Recent Activity (EN)
-        uses: Readme-Workflows/recent-activity@aa0d01a1f4efdb8595986788eccbfdd430c73b8b # v2.4.1
+        uses: Readme-Workflows/recent-activity@2750d2b82f226b7327039aa8c3ff96748396ef80 # main (2026-06-08): removes dead glitch.me telemetry; no tag released yet
         env:
           GITHUB_TOKEN: ${{ secrets.PAT }} 
         with:
           CONFIG_FILE: ./.github/config/github-activity/en.config.yml
       - name: Run Recent Activity (CA)
-        uses: Readme-Workflows/recent-activity@aa0d01a1f4efdb8595986788eccbfdd430c73b8b # v2.4.1
+        uses: Readme-Workflows/recent-activity@2750d2b82f226b7327039aa8c3ff96748396ef80 # main (2026-06-08): removes dead glitch.me telemetry; no tag released yet
         env:
           GITHUB_TOKEN: ${{ secrets.PAT }} 
         with:
           CONFIG_FILE: ./.github/config/github-activity/ca.config.yml
       - name: Run Recent Activity (IT)
-        uses: Readme-Workflows/recent-activity@aa0d01a1f4efdb8595986788eccbfdd430c73b8b # v2.4.1
+        uses: Readme-Workflows/recent-activity@2750d2b82f226b7327039aa8c3ff96748396ef80 # main (2026-06-08): removes dead glitch.me telemetry; no tag released yet
         env:
           GITHUB_TOKEN: ${{ secrets.PAT }} 
         with:
           CONFIG_FILE: ./.github/config/github-activity/it.config.yml      
       - name: Run Recent Activity (ES)
-        uses: Readme-Workflows/recent-activity@aa0d01a1f4efdb8595986788eccbfdd430c73b8b # v2.4.1
+        uses: Readme-Workflows/recent-activity@2750d2b82f226b7327039aa8c3ff96748396ef80 # main (2026-06-08): removes dead glitch.me telemetry; no tag released yet
         env:
           GITHUB_TOKEN: ${{ secrets.PAT }} 
         with:

--- a/.github/workflows/github-stars-tracker.yml
+++ b/.github/workflows/github-stars-tracker.yml
@@ -7,13 +7,14 @@ permissions:
   contents: write
 jobs:
   track-stars:
+    name: Track GitHub Stars
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           token: ${{ secrets.PAT }}
-          persist-credentials: false
+          persist-credentials: true
       - name: Track star changes
         id: tracker
         uses: fbuireu/github-star-tracker@3c16394edea2f1117e87dd8a2ec716b18d84a1ac # v1.8.5

--- a/.github/workflows/global-metrics.yml
+++ b/.github/workflows/global-metrics.yml
@@ -24,7 +24,8 @@ jobs:
           filename: assets/images/svg/github-metrics.*
           committer_token: ${{ secrets.PAT }}
           committer_message: 'docs: update ${filename}'
-          committer_branch: metrics-update-${{ github.run_number }}
+          committer_branch: main
+          output_action: pull-request-squash
           committer_gist: ""
           dryrun: no
           template: classic
@@ -103,13 +104,3 @@ jobs:
           plugin_steam: yes
           plugin_steam_token: ${{ secrets.STEAM_TOKEN }}
           plugin_steam_user: '${{ vars.STEAM_ID }}'
-      - name: Create and auto-merge PR
-        uses: ./.github/actions/create-auto-merge-pr
-        with:
-          token: ${{ secrets.PAT }}
-          commit-message: 'docs: update GitHub metrics assets'
-          title: '🤖 [AUTOMATED] Update GitHub Metrics'
-          branch: 'metrics-update-${{ github.run_number }}'
-          force-merge: 'true'
-          max-retries: '5'
-          retry-delay: '15'


### PR DESCRIPTION
Switches global-metrics to lowlighter/metrics native pull-request-squash output (fixes the metrics-update-* 404 on getRef) and includes recent-activity/star-tracker workflow tweaks.