### PR TITLE
ci: normalize step names to sentence case

### DIFF
--- a/.github/actions/create-auto-merge-pr/action.yml
+++ b/.github/actions/create-auto-merge-pr/action.yml
@@ -1,5 +1,5 @@
-name: 'Create and Auto-merge PR'
-description: 'Creates a pull request and automatically merges it if successful'
+name: Create and auto-merge PR
+description: Opens a pull request and merges it automatically once checks pass
 author: 'fbuireu'
 inputs:
   token:
@@ -40,7 +40,7 @@ outputs:
 runs:
   using: 'composite'
   steps:
-    - name: Create Pull Request
+    - name: Create pull request
       id: create-pr
       uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1
       continue-on-error: true
@@ -68,7 +68,7 @@ runs:
       shell: bash
       run: sleep 45
 
-    - name: Retry Create Pull Request
+    - name: Retry create pull request
       id: retry-pr
       if: steps.create-pr.outcome == 'failure'
       uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -8,7 +8,7 @@ jobs:
   dependency-review:
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout Repository
+      - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false

--- a/.github/workflows/follower-notifier.yml
+++ b/.github/workflows/follower-notifier.yml
@@ -9,13 +9,13 @@ jobs:
     name: Followers Notifier
     runs-on: ubuntu-latest
     steps:
-      - name: Get Followers Change
+      - name: Get followers change
         id: followers_change
         uses: Sorosliu1029/follower-change@e86fa186d8680c55cbb048d3a9d8dcb8df5b4192 # v2.3.0
         with:
           myToken: ${{ secrets.FOLLOWERS_NOTIFIER_TOKEN }}
           notifyUnFollowEvent: true
-      - name: Email Me
+      - name: Email me
         uses: dawidd6/action-send-mail@94de994a9f6fffee200243214e17002e2920bb59 # v18
         if: steps.followers_change.outputs.shouldNotify == 'true'
         with:

--- a/.github/workflows/github-activity.yml
+++ b/.github/workflows/github-activity.yml
@@ -14,30 +14,30 @@ jobs:
     name: Update README files
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout repository
+      - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           token: ${{ secrets.PAT }}
           persist-credentials: true
-      - name: Run Recent Activity (EN)
+      - name: Run recent activity (EN)
         uses: Readme-Workflows/recent-activity@2750d2b82f226b7327039aa8c3ff96748396ef80 # main (2026-06-08): removes dead glitch.me telemetry; no tag released yet
         env:
           GITHUB_TOKEN: ${{ secrets.PAT }} 
         with:
           CONFIG_FILE: ./.github/config/github-activity/en.config.yml
-      - name: Run Recent Activity (CA)
+      - name: Run recent activity (CA)
         uses: Readme-Workflows/recent-activity@2750d2b82f226b7327039aa8c3ff96748396ef80 # main (2026-06-08): removes dead glitch.me telemetry; no tag released yet
         env:
           GITHUB_TOKEN: ${{ secrets.PAT }} 
         with:
           CONFIG_FILE: ./.github/config/github-activity/ca.config.yml
-      - name: Run Recent Activity (IT)
+      - name: Run recent activity (IT)
         uses: Readme-Workflows/recent-activity@2750d2b82f226b7327039aa8c3ff96748396ef80 # main (2026-06-08): removes dead glitch.me telemetry; no tag released yet
         env:
           GITHUB_TOKEN: ${{ secrets.PAT }} 
         with:
           CONFIG_FILE: ./.github/config/github-activity/it.config.yml      
-      - name: Run Recent Activity (ES)
+      - name: Run recent activity (ES)
         uses: Readme-Workflows/recent-activity@2750d2b82f226b7327039aa8c3ff96748396ef80 # main (2026-06-08): removes dead glitch.me telemetry; no tag released yet
         env:
           GITHUB_TOKEN: ${{ secrets.PAT }} 

--- a/.github/workflows/github-stars-tracker.yml
+++ b/.github/workflows/github-stars-tracker.yml
@@ -10,7 +10,7 @@ jobs:
     name: Track GitHub Stars
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout repository
+      - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           token: ${{ secrets.PAT }}

--- a/.github/workflows/global-metrics.yml
+++ b/.github/workflows/global-metrics.yml
@@ -11,12 +11,12 @@ jobs:
     name: Update GitHub Metrics Assets
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout repository
+      - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           persist-credentials: false
-      - name: Use Metrics
+      - name: Use metrics
         uses: gh-metrics/metrics@491b81a96df4b70e14a356a2f90e38c2e84e2b84 # master (v3.35.0-beta)
         with:
           token: ${{ secrets.METRICS_TOKEN }}

--- a/.github/workflows/snake-animation.yml
+++ b/.github/workflows/snake-animation.yml
@@ -11,7 +11,7 @@ jobs:
       contents: write
       pull-requests: write
     steps:
-      - name: Checkout repository
+      - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0

--- a/.github/workflows/wakatime-stats.yml
+++ b/.github/workflows/wakatime-stats.yml
@@ -19,7 +19,7 @@ jobs:
       matrix:
         readme: [README.md, README.ca.md, README.es.md, README.it.md]
     steps:
-      - name: Checkout repository
+      - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           token: ${{ secrets.PAT }}

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -12,7 +12,7 @@ jobs:
     permissions:
       security-events: write
     steps:
-      - name: Checkout repository
+      - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -1,4 +1,4 @@
-name: Security Analysis with zizmor 🌈
+name: Security Analysis with zizmor
 on:
   push:
     branches: ["main"]
@@ -7,7 +7,7 @@ on:
 permissions: {}
 jobs:
   zizmor:
-    name: Run zizmor 🌈
+    name: Run zizmor
     runs-on: ubuntu-latest
     permissions:
       security-events: write
@@ -16,5 +16,5 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
-      - name: Run zizmor 🌈
+      - name: Run zizmor
         uses: zizmorcore/zizmor-action@3dc1ecc9bcb9e94e9b2c709687979e1298497054 # v0.6.2


### PR DESCRIPTION
Pure rename pass. No behaviour changes, no version bumps, no logic touched.

## Why

Comparing the CI across the seven repos turned up the same concept spelled several different ways:

| Concept | Variants in the wild |
|---|---|
| Checkout | `Checkout` · `Checkout repository` · `Checkout Repository` |
| Dependencies | `Install dependencies` · `Install Dependencies` |
| pnpm | `Setup pnpm` · `Install pnpm` |
| E2E | `Run E2E tests` · `Run E2E Tests` |
| Playwright | `Install Playwright browsers` · `Install Playwright Browsers` · `Install Playwright browser` |
| Typecheck | `Typecheck` · `Type check` |
| `.nvmrc` guard | `Verify .nvmrc is present` · `Validate .nvmrc exists` |

## Convention

**Sentence case** — capital on the first word and proper nouns only. It was already the majority in every repo, so this moves the minority spellings rather than inventing a new house style.

`Setup pnpm` pairs with `Setup Node.js` and matches what the action is actually called (`pnpm/action-setup`).

Composite action metadata is unquoted and sentence case too, and descriptions drop redundant trailing clauses — a "prepare environment" action installing dependencies is what the name already says.

## What is *not* touched

**Job names.** Branch protection matches required status checks by job name; renaming them would silently drop the checks from the required set. Any job-name normalization needs the protection rules updated in the same move, so it is out of scope here.
