### PR TITLE
docs: link the file references the docs cite

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -16,10 +16,10 @@
 
 <!-- Please check all that apply using "x" -->
 
-- [ ] A text fix touches **every Edition** it appears in (`README.md`, `README.ca.md`, `README.es.md`, `README.it.md`); a translation fix touches only its own
+- [ ] A text fix touches **every Edition** it appears in ([`README.md`](../README.md), [`README.ca.md`](../README.ca.md), [`README.es.md`](../README.es.md), [`README.it.md`](../README.it.md)); a translation fix touches only its own
 - [ ] I did not edit inside a Generated Region's markers, since that content is machine-written and would be overwritten within a week
 - [ ] A workflow change keeps its `permissions` block as narrow as before
-- [ ] I updated `CONTEXT.md`, `CLAUDE.md` or the ADRs if my change affects them, in this same PR
+- [ ] I updated [`CONTEXT.md`](../CONTEXT.md), [`CLAUDE.md`](../CLAUDE.md) or the ADRs if my change affects them, in this same PR
 
 ## Additional Notes
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,17 +14,17 @@ Four Editions, each a whole document ([ADR 0004](./docs/adr/0004-each-locale-is-
 
 | File | Locale | Rendered by GitHub on the profile |
 | --- | --- | --- |
-| `README.md` | English (Canonical) | yes |
-| `README.ca.md` | Catalan | no |
-| `README.es.md` | Spanish | no |
-| `README.it.md` | Italian | no |
+| [`README.md`](./README.md) | English (Canonical) | yes |
+| [`README.ca.md`](./README.ca.md) | Catalan | no |
+| [`README.es.md`](./README.es.md) | Spanish | no |
+| [`README.it.md`](./README.it.md) | Italian | no |
 
 Each carries the same two Generated Regions, addressed by marker rather than by position. The marker spelling belongs to the tool that writes it, which is why the two do not match each other. Do not "normalise" them:
 
 | Region | Markers | Written by |
 | --- | --- | --- |
-| Recent activity | `<!--RECENT_ACTIVITY:start-->` … `<!--RECENT_ACTIVITY:end-->` | `github-activity.yml` |
-| WakaTime weekly | `<!--START_SECTION:waka-->` … `<!--END_SECTION:waka-->` | `wakatime-stats.yml` |
+| Recent activity | `<!--RECENT_ACTIVITY:start-->` … `<!--RECENT_ACTIVITY:end-->` | [`github-activity.yml`](./.github/workflows/github-activity.yml) |
+| WakaTime weekly | `<!--START_SECTION:waka-->` … `<!--END_SECTION:waka-->` | [`wakatime-stats.yml`](./.github/workflows/wakatime-stats.yml) |
 
 Everything else in an Edition is an Authored Region and is expected to survive a Refresh byte-identical. Most of what looks generated in an Edition is not: the shields.io badges, the stats cards, the streak, the activity graph and the Spotify strip are Embeds, resolved live from somebody else's server when a reader opens the profile. Nothing here fetches or stores them, and nothing here notices when one dies.
 
@@ -36,12 +36,12 @@ All five content workflows share one cron, `0 0 * * 0` (Sunday 00:00 UTC), and a
 | --- | --- | --- |
 | `github-activity.yml` | the activity region in all four Editions | `main`, one Automated Update |
 | `wakatime-stats.yml` | the WakaTime region, matrix over the four Editions, `max-parallel: 1` | `main`, one Automated Update per Edition |
-| `snake-animation.yml` | `dist/github-contribution-grid-snake.svg` and `-dark.svg` | `main`, one Automated Update |
-| `global-metrics.yml` | `assets/images/svg/github-metrics.svg` | `main`, its own PR, force-merged by a step of its own, the exception in [ADR 0001](./docs/adr/0001-automated-updates-land-through-a-self-merging-pull-request.md) |
-| `github-stars-tracker.yml` | star data, charts, badge | `star-tracker-data` branch, plus an email when the count moved |
-| `follower-notifier.yml` | nothing | email only |
+| [`snake-animation.yml`](./.github/workflows/snake-animation.yml) | [`dist/github-contribution-grid-snake.svg`](./dist/github-contribution-grid-snake.svg) and `-dark.svg` | `main`, one Automated Update |
+| [`global-metrics.yml`](./.github/workflows/global-metrics.yml) | [`assets/images/svg/github-metrics.svg`](./assets/images/svg/github-metrics.svg) | `main`, its own PR, force-merged by a step of its own, the exception in [ADR 0001](./docs/adr/0001-automated-updates-land-through-a-self-merging-pull-request.md) |
+| [`github-stars-tracker.yml`](./.github/workflows/github-stars-tracker.yml) | star data, charts, badge | `star-tracker-data` branch, plus an email when the count moved |
+| [`follower-notifier.yml`](./.github/workflows/follower-notifier.yml) | nothing | email only |
 
-Four maintenance workflows run on events rather than the clock: `dependabot-auto-merge.yml` and `renovate-auto-approve.yml` handle Bot Updates, `dependency-review.yml` runs on PRs to `main`, and `zizmor.yml` audits the workflows themselves ([ADR 0003](./docs/adr/0003-third-party-actions-are-pinned-to-commit-shas.md)).
+Four maintenance workflows run on events rather than the clock: [`dependabot-auto-merge.yml`](./.github/workflows/dependabot-auto-merge.yml) and [`renovate-auto-approve.yml`](./.github/workflows/renovate-auto-approve.yml) handle Bot Updates, [`dependency-review.yml`](./.github/workflows/dependency-review.yml) runs on PRs to `main`, and [`zizmor.yml`](./.github/workflows/zizmor.yml) audits the workflows themselves ([ADR 0003](./docs/adr/0003-third-party-actions-are-pinned-to-commit-shas.md)).
 
 `.github/actions/create-auto-merge-pr` is the only first-party automation in the repository. Three Refreshes call it (`github-activity.yml`, `wakatime-stats.yml` and `snake-animation.yml`), and all three pass `force-merge: 'true'`. Read [ADR 0001](./docs/adr/0001-automated-updates-land-through-a-self-merging-pull-request.md) before changing anything in it.
 
@@ -88,8 +88,8 @@ Propose an ADR in [`docs/adr/`](./docs/adr/) when a decision is **hard to revers
 
 ## Gotchas
 
-- **`log.js` is not code.** Two lines of `console.log` whose comment says it exists to keep GitHub's CodeQL language detection happy. Nothing imports it, nothing runs it, and deleting it is the obvious tidy-up, but CodeQL is live on this repository through GitHub's default setup rather than a workflow in the tree, and its `javascript-typescript` analysis reports on every pull request. That is very likely the thing `log.js` is propping up, so leave it: it is cheap to keep and its absence would be silent.
-- **Dependabot and Renovate are both wired up, and they are not doing the same job.** Renovate is the way in for version updates: `renovate.json` classifies Bot Updates, pins digests and auto-merges pin/patch/minor. Dependabot is deliberately left with **no `dependabot.yml`**, and that absence is the configuration, because without it GitHub opens Dependabot pull requests for security advisories only, and `dependabot-auto-merge.yml` exists to land those fast. Renovate watches advisories too (`:enableVulnerabilityAlerts`, `osvVulnerabilityAlerts`); the overlap is wanted, since two advisory sources catch more than either alone.
+- **[`log.js`](./log.js) is not code.** Two lines of `console.log` whose comment says it exists to keep GitHub's CodeQL language detection happy. Nothing imports it, nothing runs it, and deleting it is the obvious tidy-up, but CodeQL is live on this repository through GitHub's default setup rather than a workflow in the tree, and its `javascript-typescript` analysis reports on every pull request. That is very likely the thing `log.js` is propping up, so leave it: it is cheap to keep and its absence would be silent.
+- **Dependabot and Renovate are both wired up, and they are not doing the same job.** Renovate is the way in for version updates: [`renovate.json`](./.github/renovate.json) classifies Bot Updates, pins digests and auto-merges pin/patch/minor. Dependabot is deliberately left with **no `dependabot.yml`**, and that absence is the configuration, because without it GitHub opens Dependabot pull requests for security advisories only, and `dependabot-auto-merge.yml` exists to land those fast. Renovate watches advisories too (`:enableVulnerabilityAlerts`, `osvVulnerabilityAlerts`); the overlap is wanted, since two advisory sources catch more than either alone.
 
   Two ways to break this, both of which look like cleanups: **adding `dependabot.yml`** turns Dependabot into a second version-update bot and the two *will* collide on the same pins and the same labels; **deleting `dependabot-auto-merge.yml`** leaves security updates sitting open with nothing to merge them.
 - **A Force Merge ignores branch protection.** Adding a required check to `main` will not gate the Refreshes; it will only gate Bot Updates ([ADR 0001](./docs/adr/0001-automated-updates-land-through-a-self-merging-pull-request.md)).

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -13,7 +13,7 @@ One complete language rendering of the Profile README. There are four (English, 
 _Avoid_: translation, locale file, variant, version
 
 **Canonical Edition**:
-The English `README.md`. It is the only Edition GitHub will ever render on the profile itself; the other three are reachable only by a reader who follows the Language Table.
+The English [`README.md`](./README.md). It is the only Edition GitHub will ever render on the profile itself; the other three are reachable only by a reader who follows the Language Table.
 _Avoid_: default readme, main readme, source of truth
 
 **Language Table**:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,8 +16,8 @@ By participating you are expected to uphold the
 
 ## The two things to know before editing
 
-1. **The profile exists in four Editions**: `README.md` (English, the one
-   GitHub renders), `README.ca.md`, `README.es.md` and `README.it.md`. Each is
+1. **The profile exists in four Editions**: [`README.md`](./README.md) (English, the one
+   GitHub renders), [`README.ca.md`](./README.ca.md), [`README.es.md`](./README.es.md) and [`README.it.md`](./README.it.md). Each is
    a whole document, deliberately not generated from a shared source. A text
    fix in one Edition almost always needs the same fix in the other three; a
    translation fix needs only its own.

--- a/docs/adr/0001-automated-updates-land-through-a-self-merging-pull-request.md
+++ b/docs/adr/0001-automated-updates-land-through-a-self-merging-pull-request.md
@@ -18,7 +18,7 @@ A Refresh has to get regenerated content onto `main`. The obvious route is the o
 
 Every Refresh that writes to `main` routes through `.github/actions/create-auto-merge-pr`. The composite action opens an Automated Update with `peter-evans/create-pull-request`, waits and retries once if creation raced another Refresh, then merges it, with `gh pr merge --auto` normally and `gh pr merge --admin` when `force-merge` is `'true'`, which is what all three callers pass. Branch names carry `github.run_number` so two Refreshes cannot collide on one branch.
 
-`global-metrics.yml` is the deliberate exception: the metrics action owns its own commit step, so it is told `output_action: pull-request` and produces its Automated Update itself. It stops there: the Force Merge is a separate step in the workflow, running `gh pr merge --admin` with the Owner Token against the head branch the metrics action names after `github.run_id`, wrapped in the same `nick-fields/retry` the composite action uses.
+[`global-metrics.yml`](../../.github/workflows/global-metrics.yml) is the deliberate exception: the metrics action owns its own commit step, so it is told `output_action: pull-request` and produces its Automated Update itself. It stops there: the Force Merge is a separate step in the workflow, running `gh pr merge --admin` with the Owner Token against the head branch the metrics action names after `github.run_id`, wrapped in the same `nick-fields/retry` the composite action uses.
 
 ## Consequences
 

--- a/docs/adr/0002-workflows-act-as-the-owner.md
+++ b/docs/adr/0002-workflows-act-as-the-owner.md
@@ -11,7 +11,7 @@ Accepted.
 `secrets.GITHUB_TOKEN` is free, scoped to this repository, expires with the job and needs no maintenance. It is the right default, and it cannot do two things this repository depends on:
 
 - **A commit made with it does not trigger another workflow.** That is a deliberate GitHub loop-breaker, and it means an Automated Update merged with `GITHUB_TOKEN` starts nothing downstream.
-- **A review submitted with it is authored by `github-actions[bot]`, not by the Owner.** `renovate-auto-approve.yml` counts approvals whose author is `github.repository_owner` before deciding whether to add one, and that check can never be satisfied by the workflow identity.
+- **A review submitted with it is authored by `github-actions[bot]`, not by the Owner.** [`renovate-auto-approve.yml`](../../.github/workflows/renovate-auto-approve.yml) counts approvals whose author is `github.repository_owner` before deciding whether to add one, and that check can never be satisfied by the workflow identity.
 
 Beyond GitHub, five Refreshes read from services that have nothing to do with this repository, and handing them a GitHub credential would be pointless as well as dangerous.
 
@@ -19,7 +19,7 @@ Beyond GitHub, five Refreshes read from services that have nothing to do with th
 
 `secrets.PAT` is the Owner Token, and it is used wherever a step must *be* the Owner: `actions/checkout` in the workflows that push, the pull request created by `create-auto-merge-pr`, `gh pr merge`, `gh pr review --approve`, and the star tracker's own repository reads.
 
-`GITHUB_TOKEN` is kept for everything that only reads or comments: the major-update comment in `dependabot-auto-merge.yml`, the checkout and `committer_token` in `global-metrics.yml`, the contribution-grid generator in `snake-animation.yml`, the orphan-branch cleanup, and (implicitly, by not being given anything else) `dependency-review.yml` and `zizmor.yml`.
+`GITHUB_TOKEN` is kept for everything that only reads or comments: the major-update comment in [`dependabot-auto-merge.yml`](../../.github/workflows/dependabot-auto-merge.yml), the checkout and `committer_token` in [`global-metrics.yml`](../../.github/workflows/global-metrics.yml), the contribution-grid generator in [`snake-animation.yml`](../../.github/workflows/snake-animation.yml), the orphan-branch cleanup, and (implicitly, by not being given anything else) [`dependency-review.yml`](../../.github/workflows/dependency-review.yml) and [`zizmor.yml`](../../.github/workflows/zizmor.yml).
 
 Every external service gets its own Integration Token, named for that service and granting nothing on GitHub: `METRICS_TOKEN`, `WAKATIME_TOKEN`, `FOLLOWERS_NOTIFIER_TOKEN`, `SPOTIFY_CLIENT_ID`/`SPOTIFY_CLIENT_SECRET`/`SPOTIFY_REFRESH_TOKEN`, `STEAM_TOKEN`, `GOOGLE_MAPS_TOKEN`, `PAGESPEED_TOKEN`, `MAIL_PASSWORD`. The Owner Token is never passed to one.
 
@@ -27,4 +27,4 @@ Every external service gets its own Integration Token, named for that service an
 
 - **The blast radius is every repository the Owner can write to**, not just this one. That is the price paid, and it is why [ADR 0003](./0003-third-party-actions-are-pinned-to-commit-shas.md) exists: an unpinned third-party action running on a schedule with this token in the environment is the realistic way it leaks.
 - **When the token expires, every Refresh breaks at once**, and the failures do not say "expired token": they surface as a 403 on checkout or as a merge step that silently exhausts its retries.
-- **`persist-credentials` is load-bearing per workflow, not a style choice.** `github-activity.yml` sets it to `true` because the recent-activity action pushes with the credentials checkout left behind; the others set `false` because they hand the token to a step explicitly. Flipping either breaks that workflow only, and `zizmor` will flag the `true`, which is intentional.
+- **`persist-credentials` is load-bearing per workflow, not a style choice.** [`github-activity.yml`](../../.github/workflows/github-activity.yml) sets it to `true` because the recent-activity action pushes with the credentials checkout left behind; the others set `false` because they hand the token to a step explicitly. Flipping either breaks that workflow only, and `zizmor` will flag the `true`, which is intentional.

--- a/docs/adr/0003-third-party-actions-are-pinned-to-commit-shas.md
+++ b/docs/adr/0003-third-party-actions-are-pinned-to-commit-shas.md
@@ -14,7 +14,7 @@ Pinning to tags is what almost every profile repository does, reads better, and 
 
 ## Decision
 
-Every `uses:` names a full commit SHA, with the human-readable version in a trailing comment. Renovate maintains both (`pinDigests: true` and `rangeStrategy: pin` in `.github/renovate.json`), and pin, patch and minor Bot Updates merge themselves while major ones wait for the Owner. `zizmor.yml` runs on every push to `main` and every pull request and reports into code scanning, so a regression is caught on the Bot Update that introduces it.
+Every `uses:` names a full commit SHA, with the human-readable version in a trailing comment. Renovate maintains both (`pinDigests: true` and `rangeStrategy: pin` in [`.github/renovate.json`](../../.github/renovate.json)), and pin, patch and minor Bot Updates merge themselves while major ones wait for the Owner. [`zizmor.yml`](../../.github/workflows/zizmor.yml) runs on every push to `main` and every pull request and reports into code scanning, so a regression is caught on the Bot Update that introduces it.
 
 Two pins deliberately reference a branch commit rather than a release, and the comment says why rather than leaving a reader to guess: `Readme-Workflows/recent-activity` (the commit that removes dead glitch.me telemetry is unreleased) and `athul/waka-readme` (master).
 
@@ -23,4 +23,4 @@ Two pins deliberately reference a branch commit rather than a release, and the c
 - **The trailing comment is the only readable version anywhere.** Renovate rewrites it with the SHA; editing one by hand desynchronises the two and nothing checks it.
 - **The two branch pins never advance on their own.** Renovate has no release to compare against, so they stay where they are until someone looks, which is the point, but it means "pinned" here also means "frozen".
 - **A major Bot Update blocks a Refresh silently.** It sits open, labelled `major-update,review-required`, while the workflow keeps running the old SHA quite happily. Nothing escalates.
-- **`zizmor` is not advisory.** It is the only automated check here with anything to inspect (`dependency-review.yml` runs on every pull request too, but there is no manifest in this repository for it to review), and it is why `persist-credentials: false` appears on the checkouts that do not need credentials.
+- **`zizmor` is not advisory.** It is the only automated check here with anything to inspect ([`dependency-review.yml`](../../.github/workflows/dependency-review.yml) runs on every pull request too, but there is no manifest in this repository for it to review), and it is why `persist-credentials: false` appears on the checkouts that do not need credentials.

--- a/docs/adr/0004-each-locale-is-a-whole-edition.md
+++ b/docs/adr/0004-each-locale-is-a-whole-edition.md
@@ -8,7 +8,7 @@ Accepted.
 
 ## Context
 
-The Profile README exists in four languages. GitHub renders exactly one of them, `README.md`, so the other three are a courtesy to readers who follow the Language Table, not a requirement of the platform.
+The Profile README exists in four languages. GitHub renders exactly one of them, [`README.md`](../../README.md), so the other three are a courtesy to readers who follow the Language Table, not a requirement of the platform.
 
 The tidy option is one source document plus a translation table, rendered into four files by a build step. It costs this repository something it currently does not spend: a toolchain. There is no `package.json` here, no dependency to install, nothing to run locally: the repository is markdown, images and YAML, and every generator is a third-party action. A renderer would make the four Editions consistent by construction and make the repository something you have to build.
 
@@ -16,8 +16,8 @@ The tidy option is one source document plus a translation table, rendered into f
 
 Each Edition is a complete, hand-written document carrying its own Generated Regions. Automation fans out over the four files rather than over one source:
 
-- `wakatime-stats.yml` runs a matrix over `README.md`, `README.ca.md`, `README.es.md`, `README.it.md`, with `max-parallel: 1` so four Automated Updates do not race each other onto `main`.
-- `github-activity.yml` invokes the same action four times, once per config under `.github/config/github-activity/`. Those configs are also where the per-locale wording of activity lines lives, and `en.config.yml` carries no `messages:` block because English is the action's default.
+- [`wakatime-stats.yml`](../../.github/workflows/wakatime-stats.yml) runs a matrix over `README.md`, [`README.ca.md`](../../README.ca.md), [`README.es.md`](../../README.es.md), [`README.it.md`](../../README.it.md), with `max-parallel: 1` so four Automated Updates do not race each other onto `main`.
+- [`github-activity.yml`](../../.github/workflows/github-activity.yml) invokes the same action four times, once per config under `.github/config/github-activity/`. Those configs are also where the per-locale wording of activity lines lives, and [`en.config.yml`](../../.github/config/github-activity/en.config.yml) carries no `messages:` block because English is the action's default.
 
 ## Consequences
 


### PR DESCRIPTION
## Description

Every document that names a file in prose or in a table now points at it. The first mention of a given file in a document becomes a relative markdown link; later mentions stay plain, so a paragraph does not turn into a list of links. 47 links across 8 markdown files — `CLAUDE.md`, `CONTEXT.md`, `CONTRIBUTING.md`, the PR template and the four ADRs.

The four README Editions are untouched, so the rendered profile page is byte-for-byte what it was.

## Type of Change

- [ ] ✏️ Text fix (typo, wording, dead link)
- [ ] 🌐 Translation fix (one Edition only)
- [ ] 🖼️ Asset change
- [ ] ⚙️ Workflow change
- [x] 📝 Documentation update

## Checklist

- [x] A text fix touches **every Edition** it appears in (`README.md`, `README.ca.md`, `README.es.md`, `README.it.md`); a translation fix touches only its own — no Edition changed; where the guides *name* the Editions, the name is now a link to that file
- [x] I did not edit inside a Generated Region's markers, since that content is machine-written and would be overwritten within a week — no README touched at all, so no marker went near this change
- [x] A workflow change keeps its `permissions` block as narrow as before — no workflow changed; the guides now link to each one they name
- [x] I updated `CONTEXT.md`, `CLAUDE.md` or the ADRs if my change affects them, in this same PR

## Additional Notes

- What became a link: the four Editions, each workflow named in the tables (`github-activity.yml`, `wakatime-stats.yml`, `snake-animation.yml`, `global-metrics.yml`, `github-stars-tracker.yml`, `follower-notifier.yml` and the four maintenance ones), the artefacts they write (`dist/github-contribution-grid-snake.svg`, `assets/images/svg/github-metrics.svg`), `.github/renovate.json` and `log.js`.
- Nothing inside code fences, headings or HTML tags was touched, and no generated region was entered.
- Paragraphs that gained a link now run past the wrap of the surrounding prose. Reflowing them would have buried the change in whitespace noise, so the lines are left long. Say the word and they get rewrapped.


---
_Generated by [Claude Code](https://claude.ai/code/session_01MvVEHADoH6osNhSZ3PTfPH)_